### PR TITLE
use File::Spec and File::Basename directly

### DIFF
--- a/lib/CPAN/Common/Index/LocalPackage.pm
+++ b/lib/CPAN/Common/Index/LocalPackage.pm
@@ -57,8 +57,9 @@ sub cached_package {
 sub refresh_index {
     my ($self) = @_;
     my $source = $self->source;
+    my $basename = File::Basename::basename($source);
     if ( $source =~ /\.gz$/ ) {
-        ( my $uncompressed = File::Basename::basename($source) ) =~ s/\.gz$//;
+        ( my $uncompressed = $basename ) =~ s/\.gz$//;
         $uncompressed = File::Spec->catfile( $self->cache, $uncompressed );
         if ( !-f $uncompressed or (stat $source)[9] > (stat $uncompressed)[9] ) {
             IO::Uncompress::Gunzip::gunzip( map { "$_" } $source, $uncompressed )
@@ -66,7 +67,7 @@ sub refresh_index {
         }
     }
     else {
-        my $dest = File::Spec->catfile( $self->cache, File::Basename::basename($source) );
+        my $dest = File::Spec->catfile( $self->cache, $basename );
         File::Copy::copy($source, $dest)
           if !-e $dest || (stat $source)[9] > (stat $dest)[9];
     }

--- a/lib/CPAN/Common/Index/LocalPackage.pm
+++ b/lib/CPAN/Common/Index/LocalPackage.pm
@@ -13,7 +13,9 @@ use Class::Tiny qw/source/;
 
 use Carp;
 use IO::Uncompress::Gunzip ();
-use Path::Tiny;
+use File::Basename ();
+use File::Copy ();
+use File::Spec;
 
 =attr source (REQUIRED)
 
@@ -44,7 +46,9 @@ sub BUILD {
 
 sub cached_package {
     my ($self) = @_;
-    my $package = path( $self->cache, path( $self->source )->basename );
+    my $package = File::Spec->catfile(
+        $self->cache, File::Basename::basename($self->source)
+    );
     $package =~ s/\.gz$//;
     $self->refresh_index unless -r $package;
     return $package;
@@ -52,19 +56,19 @@ sub cached_package {
 
 sub refresh_index {
     my ($self) = @_;
-    my $source = path( $self->source );
+    my $source = $self->source;
     if ( $source =~ /\.gz$/ ) {
-        ( my $uncompressed = $source->basename ) =~ s/\.gz$//;
-        $uncompressed = path( $self->cache, $uncompressed );
-        if ( !-f $uncompressed or $source->stat->mtime > $uncompressed->stat->mtime ) {
+        ( my $uncompressed = File::Basename::basename($source) ) =~ s/\.gz$//;
+        $uncompressed = File::Spec->catfile( $self->cache, $uncompressed );
+        if ( !-f $uncompressed or (stat $source)[9] > (stat $uncompressed)[9] ) {
             IO::Uncompress::Gunzip::gunzip( map { "$_" } $source, $uncompressed )
               or Carp::croak "gunzip failed: $IO::Uncompress::Gunzip::GunzipError\n";
         }
     }
     else {
-        my $dest = path( $self->cache, $source->basename );
-        $source->copy($dest)
-          if !-e $dest || $source->stat->mtime > $dest->stat->mtime;
+        my $dest = File::Spec->catfile( $self->cache, File::Basename::basename($source) );
+        File::Copy::copy($source, $dest)
+          if !-e $dest || (stat $source)[9] > (stat $dest)[9];
     }
     return 1;
 }

--- a/lib/CPAN/Common/Index/LocalPackage.pm
+++ b/lib/CPAN/Common/Index/LocalPackage.pm
@@ -16,6 +16,7 @@ use IO::Uncompress::Gunzip ();
 use File::Basename ();
 use File::Copy ();
 use File::Spec;
+use File::stat ();
 
 =attr source (REQUIRED)
 
@@ -61,7 +62,8 @@ sub refresh_index {
     if ( $source =~ /\.gz$/ ) {
         ( my $uncompressed = $basename ) =~ s/\.gz$//;
         $uncompressed = File::Spec->catfile( $self->cache, $uncompressed );
-        if ( !-f $uncompressed or (stat $source)[9] > (stat $uncompressed)[9] ) {
+        if ( !-f $uncompressed
+              or File::stat::stat($source)->mtime > File::stat::stat($uncompressed)->mtime ) {
             IO::Uncompress::Gunzip::gunzip( map { "$_" } $source, $uncompressed )
               or Carp::croak "gunzip failed: $IO::Uncompress::Gunzip::GunzipError\n";
         }
@@ -69,7 +71,7 @@ sub refresh_index {
     else {
         my $dest = File::Spec->catfile( $self->cache, $basename );
         File::Copy::copy($source, $dest)
-          if !-e $dest || (stat $source)[9] > (stat $dest)[9];
+          if !-e $dest || File::stat::stat($source)->mtime > File::stat::stat($dest)->mtime;
     }
     return 1;
 }

--- a/t/local_package.t
+++ b/t/local_package.t
@@ -14,7 +14,7 @@ use lib 't/lib';
 use CommonTests;
 
 my $cwd          = getcwd;
-my $cache        = File::Temp::tempdir(CLEANUP => 1);
+my $cache        = File::Temp::tempdir(CLEANUP => 1, TMPDIR => 1);
 my $localgz      = File::Spec->catfile(qw/t CUSTOM mypackages.gz/);
 my $local        = File::Spec->catfile(qw/t CUSTOM uncompressed/);
 my $packages     = "mypackages";

--- a/t/local_package.t
+++ b/t/local_package.t
@@ -7,15 +7,16 @@ use Test::Deep '!blessed';
 use Test::Fatal;
 
 use Cwd qw/getcwd/;
-use Path::Tiny;
+use File::Spec;
+use File::Temp ();
 
 use lib 't/lib';
 use CommonTests;
 
 my $cwd          = getcwd;
-my $cache        = Path::Tiny->tempdir;
-my $localgz      = path(qw/t CUSTOM mypackages.gz/);
-my $local        = path(qw/t CUSTOM uncompressed/);
+my $cache        = File::Temp::tempdir(CLEANUP => 1);
+my $localgz      = File::Spec->catfile(qw/t CUSTOM mypackages.gz/);
+my $local        = File::Spec->catfile(qw/t CUSTOM uncompressed/);
 my $packages     = "mypackages";
 my $uncompressed = "uncompressed";
 
@@ -68,21 +69,21 @@ subtest "constructor tests" => sub {
 subtest 'refresh and unpack index files' => sub {
     my $index = new_local_index;
 
-    ok( !path( $cache, $packages )->exists, "$packages not in cache" );
+    ok( !-e File::Spec->catfile( $cache, $packages ), "$packages not in cache" );
 
     ok( $index->refresh_index, "refreshed index" );
 
-    ok( path( $cache, $packages )->exists, "$packages in cache" );
+    ok( -e File::Spec->catfile( $cache, $packages ), "$packages in cache" );
 };
 
 subtest 'refresh and unpack uncompressed index files' => sub {
     my $index = new_uncompressed_local_index;
 
-    ok( !path( $cache, $uncompressed )->exists, "$uncompressed not in cache" );
+    ok( !-e File::Spec->catfile( $cache, $uncompressed ), "$uncompressed not in cache" );
 
     ok( $index->refresh_index, "refreshed index" );
 
-    ok( path( $cache, $uncompressed )->exists, "$uncompressed in cache" );
+    ok( -e File::Spec->catfile( $cache, $uncompressed ), "$uncompressed in cache" );
 };
 
 # XXX test that files in cache aren't overwritten?


### PR DESCRIPTION
Address a part of #16 

This PR modifies lib/CPAN/Common/Index/LocalPackage.pm to use File::Spec and File::Basename directly istead of Path::Tiny.

This makes CPAN-Common-Index more fatpack friendly,
and I think it's okay to use File::Spec and File::Basename directly here because we already use them in CPAN::Common::Index::Mirror.