### PR TITLE
fall back to gzip command if IO::Uncompress::Gunzip is not available

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,3 +19,9 @@ stopwords = mailrc
 stopwords = resolvers
 stopwords = txt
 stopwords = uri
+
+[RemovePrereqs]
+remove = IO::Uncompress::Gunzip
+
+[Prereqs / Recommends]
+IO::Uncompress::Gunzip = 0

--- a/lib/CPAN/Common/Index/LocalPackage.pm
+++ b/lib/CPAN/Common/Index/LocalPackage.pm
@@ -12,7 +12,7 @@ use parent 'CPAN::Common::Index::Mirror';
 use Class::Tiny qw/source/;
 
 use Carp;
-use IO::Uncompress::Gunzip ();
+use CPAN::Common::Index::Util;
 use File::Basename ();
 use File::Copy ();
 use File::Spec;
@@ -64,8 +64,8 @@ sub refresh_index {
         $uncompressed = File::Spec->catfile( $self->cache, $uncompressed );
         if ( !-f $uncompressed
               or File::stat::stat($source)->mtime > File::stat::stat($uncompressed)->mtime ) {
-            IO::Uncompress::Gunzip::gunzip( map { "$_" } $source, $uncompressed )
-              or Carp::croak "gunzip failed: $IO::Uncompress::Gunzip::GunzipError\n";
+            eval { CPAN::Common::Index::Util::gunzip( $source, $uncompressed ) }
+              or Carp::croak $@;
         }
     }
     else {

--- a/lib/CPAN/Common/Index/Mirror.pm
+++ b/lib/CPAN/Common/Index/Mirror.pm
@@ -16,7 +16,7 @@ use CPAN::DistnameInfo;
 use File::Basename ();
 use File::Fetch;
 use File::Temp 0.19; # newdir
-use IO::Uncompress::Gunzip ();
+use CPAN::Common::Index::Util;
 use Search::Dict 1.07;
 use Tie::Handle::SkipHeader;
 use URI;
@@ -118,8 +118,8 @@ sub refresh_index {
         my $where = $ff->fetch( to => $self->cache )
           or Carp::croak( $ff->error );
         ( my $uncompressed = $where ) =~ s/\.gz$//;
-        IO::Uncompress::Gunzip::gunzip( $where, $uncompressed )
-          or Carp::croak "gunzip failed: $IO::Uncompress::Gunzip::GunzipError\n";
+        eval { CPAN::Common::Index::Util::gunzip( $where, $uncompressed ) }
+          or Carp::croak $@;
     }
     return 1;
 }

--- a/lib/CPAN/Common/Index/Util.pm
+++ b/lib/CPAN/Common/Index/Util.pm
@@ -1,0 +1,30 @@
+use 5.008001;
+use strict;
+use warnings;
+
+package CPAN::Common::Index::Util;
+# ABSTRACT: Utility functions for CPAN::Common::Index
+
+our $VERSION = '0.008';
+
+sub gunzip {
+    my ($src, $dest) = @_;
+    if ( eval { require IO::Uncompress::Gunzip } ) {
+        no warnings 'once';
+        IO::Uncompress::Gunzip::gunzip($src, $dest)
+          or die "gunzip failed: $IO::Uncompress::Gunzip::GunzipError\n";
+        return 1;
+    }
+    else {
+        require File::Which;
+        require IPC::Run3;
+        my $gzip = File::Which::which("gzip")
+          or die "can't find IO::Uncompress::Gunzip nor gzip command\n";
+        IPC::Run3::run3( [$gzip, '--decompress', '--stdout', $src], \undef, $dest, \my $err );
+        return 1 if $? == 0;
+        chomp $err;
+        die $err ? $err : "gunzip failed: \$? = $?", "\n";
+    }
+}
+
+1;


### PR DESCRIPTION
Address #16 

This is `option a3` described in #16.
That is, try to load IO::Uncompress::Gunzip first, and if it is not available, try to use external gzip command with File::Which and IPC::Run3.

@xdg You suggested `option a1`, but I think it would be nice to fall back to external gzip command. Feel free to reject this pull request. Then I will raise another pull request for `option a1` or some other options.

Note that this pull request introduces a new dependencies File::Which and IPC::Run3.